### PR TITLE
Guard against NullReferenceException in integration test when empty connection string is passed in

### DIFF
--- a/Tailor.Test/TheTailor.cs
+++ b/Tailor.Test/TheTailor.cs
@@ -23,6 +23,11 @@ namespace Tailor.Test
 
         public static TheTailor Create(string connectionString, Type[] exportedAssemblyTypes)
         {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException($"A valid connection string is required when creating {nameof(TheTailor)}");
+            }
+
             return Create(new SqlConnectionFactory(connectionString), exportedAssemblyTypes);
         }
 

--- a/Tailor.Test/TheTailor.cs
+++ b/Tailor.Test/TheTailor.cs
@@ -25,7 +25,7 @@ namespace Tailor.Test
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException($"A valid connection string is required when creating {nameof(TheTailor)}");
+                throw new ArgumentException($"A valid connection string is required when creating {nameof(TheTailor)}");
             }
 
             return Create(new SqlConnectionFactory(connectionString), exportedAssemblyTypes);

--- a/Tailor.Tests/TheTailorTests.cs
+++ b/Tailor.Tests/TheTailorTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using Shouldly;
+using Tailor.Test;
+using Tailor.Tests.Sample;
+
+namespace Tailor.Tests
+{
+    public class TheTailorTests
+    {
+        [Test]
+        public void WhenCreatingTheTailorWithAnEmptyConnectionString_ThrowsAnException()
+        {
+            Should.Throw<ArgumentException>(() => TheTailor.Create(string.Empty, typeof(IAmTheQueryAssembly).Assembly.GetExportedTypes()
+                .Where(x => x.Namespace == "Tailor.Tests.Sample").ToArray()));
+        }
+    }
+}


### PR DESCRIPTION
Fail early if an empty connection string is passed into factory method (was throwing a NullReferenceException when executing queries with empty connection string). 