### PR TITLE
Update NuGet-related MSBuild properties

### DIFF
--- a/Tailor/Tailor.csproj
+++ b/Tailor/Tailor.csproj
@@ -6,10 +6,10 @@
     <Title>Tailor</Title>
     <Authors>Andrew Best</Authors>
     <Owners>Andrew Best</Owners>
-    <ProjectUrl>https://github.com/andrewabest/Tailor</ProjectUrl>
+    <PackageProjectUrl>https://github.com/andrewabest/Tailor</PackageProjectUrl>
     <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <Description>A set of opinionated Query abstractions and accompanying Convention Tests to make sure your Dapper queries measure up</Description>
-    <IconUrl>https://raw.github.com/andrewabest/Conventional/master/suit.png</IconUrl>
+    <PackageIconUrl>https://raw.github.com/andrewabest/Conventional/master/suit.png</PackageIconUrl>
     <Tags>Dapper</Tags>
     <Copyright>Copyright © 2017, Andrew Best</Copyright>
     <Version>0.0.0.0</Version>


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties

[Someone found out on Twitter](https://twitter.com/reubenbond/status/989649978380378112) that the NuGet package page doesn't link back to the GitHub repository.